### PR TITLE
fix: address issues from PR #2 merge

### DIFF
--- a/internal/commands/cobra.go
+++ b/internal/commands/cobra.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"codes/internal/ui"
-	"strings"
 )
 
 // InitCmd represents the init command

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -984,7 +984,7 @@ func runClaudeInDirectory(dir string) {
 	}
 
 	// Set environment variables
-	config.SetEnvironmentVarsWithConfig(&selectedConfig, cfg)
+	config.SetEnvironmentVarsWithConfig(&selectedConfig)
 
 	ui.ShowInfo("Using configuration: %s", selectedConfig.Name)
 	ui.ShowInfo("Working directory: %s", dir)
@@ -1187,7 +1187,7 @@ func RunConfigSet(key, value string) {
 		cfg.DefaultBehavior = value
 		ui.ShowSuccess("Default behavior set to: %s", value)
 	default:
-		ui.ShowError("Unknown configuration key: %s", nil)
+		ui.ShowError(fmt.Sprintf("Unknown configuration key: %s", key), nil)
 		fmt.Printf("Available keys: defaultBehavior\n")
 		return
 	}
@@ -1213,7 +1213,7 @@ func RunConfigGet(args []string) {
 		case "defaultBehavior":
 			fmt.Printf("%s: %s\n", key, cfg.DefaultBehavior)
 		default:
-			ui.ShowError("Unknown configuration key: %s", nil)
+			ui.ShowError(fmt.Sprintf("Unknown configuration key: %s", key), nil)
 			fmt.Printf("Available keys: defaultBehavior\n")
 			return
 		}


### PR DESCRIPTION
## Summary

- Add backward-compatible config migration via custom `UnmarshalJSON` — old flat-field configs are auto-migrated to the new `env` map format
- Fix JSON injection in `TestAPIConfig` by replacing `fmt.Sprintf` with `json.Marshal`
- Fix format string bugs in `RunConfigSet`/`RunConfigGet` where `%s` was never substituted
- Remove unused `cfg` parameter from `SetEnvironmentVarsWithConfig`
- Fix import ordering in `cobra.go`
- Replace `log.Printf` with `fmt.Fprintf` for consistent logging style

## Test plan

- [ ] Verify old-format config.json loads correctly and env vars are migrated
- [ ] Verify `codes test` works with model names containing special characters
- [ ] Verify `codes config get invalidkey` shows the key name in error message
- [ ] Verify `go build ./...` passes

Fixes #4, Fixes #5, Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored environment-variable/config handling for clearer behavior and maintainability.
  * Added automatic migration of legacy configuration fields so older configs continue to work.

* **Bug Fixes**
  * Standardized error messaging for unknown configuration keys.
  * Improved how external processes are launched so commands run in the intended directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->