### PR TITLE
fix: set GOOS/GOARCH for correct cross-compilation in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,21 +14,27 @@ jobs:
           - platform: ubuntu-latest
             goos: linux
             goarch: amd64
+            can_test: true
           - platform: ubuntu-latest
             goos: linux
             goarch: arm64
+            can_test: false
           - platform: windows-latest
             goos: windows
             goarch: amd64
+            can_test: true
           - platform: windows-latest
             goos: windows
             goarch: arm64
+            can_test: false
           - platform: macos-latest
             goos: darwin
             goarch: amd64
+            can_test: false
           - platform: macos-latest
             goos: darwin
             goarch: arm64
+            can_test: true
 
     runs-on: ${{ matrix.platform }}
 
@@ -47,6 +53,10 @@ jobs:
 
     - name: Build codes
       shell: bash
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
+        CGO_ENABLED: '0'
       run: |
         if [ "${{ matrix.goos }}" = "windows" ]; then
           go build -o codes.exe ./cmd/codes
@@ -55,6 +65,7 @@ jobs:
         fi
 
     - name: Test
+      if: matrix.can_test
       shell: bash
       run: |
         if [ "${{ matrix.goos }}" = "windows" ]; then


### PR DESCRIPTION
## Summary

- Build step 添加 `GOOS`/`GOARCH`/`CGO_ENABLED=0` 环境变量，确保交叉编译产物架构与文件名匹配
- Matrix 添加 `can_test` 字段，跳过无法在当前 runner 上执行的交叉编译二进制测试

## Problem

Release workflow 的 `go build` 没有设置 `GOOS`/`GOARCH`，导致所有构建使用 runner 原生架构：
- `macos-latest` (arm64) → `codes-darwin-amd64` 实际是 arm64 ❌
- `ubuntu-latest` (amd64) → `codes-linux-arm64` 实际是 amd64 ❌
- `windows-latest` (amd64) → `codes-windows-arm64` 实际是 amd64 ❌

## Test plan

- [x] 本地验证：`GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build` 产物经 `file` 确认为 ARM aarch64
- [ ] 推送 tag 触发 release workflow，检查产物架构是否正确

Closes #3